### PR TITLE
Exclude \r\n after {octet-count} from the count

### DIFF
--- a/conn/command_fetch.go
+++ b/conn/command_fetch.go
@@ -155,7 +155,7 @@ func fetchInternalDate(args []string, c *Conn, m mailstore.Message, peekOnly boo
 }
 
 func fetchHeaders(args []string, c *Conn, m mailstore.Message, peekOnly bool) string {
-	hdr := fmt.Sprintf("\r\n%s\r\n\r\n", m.Header())
+	hdr := fmt.Sprintf("%s\r\n\r\n", m.Header())
 	hdrLen := len(hdr)
 
 	peekStr := ""
@@ -163,7 +163,7 @@ func fetchHeaders(args []string, c *Conn, m mailstore.Message, peekOnly bool) st
 		peekStr = ".PEEK"
 	}
 
-	return fmt.Sprintf("BODY%s[HEADER] {%d}%s", peekStr, hdrLen, hdr)
+	return fmt.Sprintf("BODY%s[HEADER] {%d}\r\n%s", peekStr, hdrLen, hdr)
 }
 
 func fetchHeaderSpecificFields(args []string, c *Conn, m mailstore.Message, peekOnly bool) string {
@@ -181,10 +181,10 @@ func fetchHeaderSpecificFields(args []string, c *Conn, m mailstore.Message, peek
 			requestedHeaders[k] = v
 		}
 	}
-	hdr := fmt.Sprintf("\r\n%s\r\n\r\n", requestedHeaders)
+	hdr := fmt.Sprintf("%s\r\n\r\n", requestedHeaders)
 	hdrLen := len(hdr)
 
-	return fmt.Sprintf("BODY[HEADER.FIELDS (%s)] {%d}%s",
+	return fmt.Sprintf("BODY[HEADER.FIELDS (%s)] {%d}\r\n%s",
 		strings.Join(replyFieldList, " "),
 		hdrLen,
 		hdr)
@@ -192,17 +192,17 @@ func fetchHeaderSpecificFields(args []string, c *Conn, m mailstore.Message, peek
 }
 
 func fetchBody(args []string, c *Conn, m mailstore.Message, peekOnly bool) string {
-	body := fmt.Sprintf("\r\n%s\r\n", m.Body())
+	body := fmt.Sprintf("%s\r\n", m.Body())
 	bodyLen := len(body)
 
-	return fmt.Sprintf("BODY[TEXT] {%d}%s",
+	return fmt.Sprintf("BODY[TEXT] {%d}\r\n%s",
 		bodyLen, body)
 }
 
 func fetchFullText(args []string, c *Conn, m mailstore.Message, peekOnly bool) string {
-	mail := fmt.Sprintf("\r\n%s\r\n\r\n%s\r\n", m.Header(), m.Body())
+	mail := fmt.Sprintf("%s\r\n\r\n%s\r\n", m.Header(), m.Body())
 	mailLen := len(mail)
 
-	return fmt.Sprintf("BODY[] {%d}%s",
+	return fmt.Sprintf("BODY[] {%d}\r\n%s",
 		mailLen, mail)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -185,7 +185,7 @@ func TestFetchHeader(t *testing.T) {
 	r.sConn.SelectedMailbox = r.mailstore.User.Mailboxes()[0]
 	go r.sConn.Start()
 	r.cConn.PrintfLine("abcd.123 FETCH 1 (BODY[HEADER])")
-	r.expect(t, "* 1 FETCH (BODY[HEADER] {128}")
+	r.expect(t, "* 1 FETCH (BODY[HEADER] {126}")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
@@ -204,7 +204,7 @@ func TestFetchSpecificHeaders(t *testing.T) {
 	r.sConn.SelectedMailbox = r.mailstore.User.Mailboxes()[0]
 	go r.sConn.Start()
 	r.cConn.PrintfLine("abcd.123 FETCH 1 (BODY[HEADER.FIELDS (From Subject)])")
-	r.expect(t, "* 1 FETCH (BODY[HEADER.FIELDS (\"From\" \"Subject\")] {44}")
+	r.expect(t, "* 1 FETCH (BODY[HEADER.FIELDS (\"From\" \"Subject\")] {42}")
 	r.expectPattern(t, "^((?i)(subject)|(from)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expectPattern(t, "^((?i)(subject)|(from)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expect(t, "")
@@ -220,7 +220,7 @@ func TestFetchPeekSpecificHeaders(t *testing.T) {
 	r.sConn.SelectedMailbox = r.mailstore.User.Mailboxes()[0]
 	go r.sConn.Start()
 	r.cConn.PrintfLine("abcd.123 FETCH 1 (BODY.PEEK[HEADER.FIELDS (from Subject x-priority)])")
-	r.expect(t, "* 1 FETCH (BODY[HEADER.FIELDS (\"from\" \"Subject\" \"x-priority\")] {44}")
+	r.expect(t, "* 1 FETCH (BODY[HEADER.FIELDS (\"from\" \"Subject\" \"x-priority\")] {42}")
 	r.expectPattern(t, "^((?i)(subject)|(from)): [A-z0-9\\s@\\.]+$")
 	r.expectPattern(t, "^((?i)(subject)|(from)): [A-z0-9\\s@\\.]+$")
 	r.expect(t, "")
@@ -260,7 +260,7 @@ func TestFetchBodyOnly(t *testing.T) {
 	r.sConn.SelectedMailbox = r.mailstore.User.Mailboxes()[0]
 	go r.sConn.Start()
 	r.cConn.PrintfLine("abcd.123 FETCH 1 (BODY[TEXT])")
-	r.expect(t, "* 1 FETCH (BODY[TEXT] {28}")
+	r.expect(t, "* 1 FETCH (BODY[TEXT] {26}")
 	r.expect(t, "Test email")
 	r.expect(t, "Regards,")
 	r.expect(t, "Me")
@@ -276,7 +276,7 @@ func TestFetchFullMessage(t *testing.T) {
 	r.sConn.SelectedMailbox = r.mailstore.User.Mailboxes()[0]
 	go r.sConn.Start()
 	r.cConn.PrintfLine("abcd.123 FETCH 1 (BODY[])")
-	r.expect(t, "* 1 FETCH (BODY[] {154}")
+	r.expect(t, "* 1 FETCH (BODY[] {152}")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
@@ -298,7 +298,7 @@ func TestFetchFullMessageByUID(t *testing.T) {
 	r.sConn.SelectedMailbox = r.mailstore.User.Mailboxes()[0]
 	go r.sConn.Start()
 	r.cConn.PrintfLine("abcd.123 UID FETCH 11 (BODY[])")
-	r.expect(t, "* 2 FETCH (BODY[] {156}")
+	r.expect(t, "* 2 FETCH (BODY[] {154}")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")
 	r.expectPattern(t, "^((?i)(subject)|(message-id)|(to)|(from)|(date)): [<>A-z0-9\\s@\\.,\\:\\+]+$")


### PR DESCRIPTION
Hello,

First off, thank you very much for writing this. I was dreading the prospect
of having to integrate Dovecot into a test suite when I found this project.
It's small, beautiful, hackable, and comes with an in-memory backend!

I found this bug (I presume it is a bug; I am open to being corrected), while
testing with mbsync. FETCH did not work properly, and mbsync's debug output
produced the following:

```
>>> 6 UID FETCH 10 (BODY.PEEK[])
…
* 1 FETCH (BODY[] {154}
ID 10)
IMAP error: unexpected FETCH response (UID 0)
```

A little printf debugging inside of mbsync revealed that the `ID 10)` line
was not bogus output, but instead being being interpreted as the list tokens
(`ID`, `10`).

This looked suspiciously like an indexing error, and a skim through RFC 3501
yielded an explanation.

Thanks again!

From the patch header:

According to RFC 3501 § 4.3¹:

    4.3.    String

       …

       A literal is a sequence of zero or more octets (including CR and
       LF), prefix-quoted with an octet count in the form of an open
       brace ("{"), the number of octets, close brace ("}"), a̲n̲d̲ ̲C̲R̲L̲F̲.
       …

Reading carefully, the CRLF following {octet-count} is not considered
part of the string literal, but rather as part of the prefix.

Therefore, the octet-count should not include the \r\n.

¹ https://tools.ietf.org/html/rfc3501#section-4.3
