### PR TITLE
Fix tests, change Serve and remove Close

### DIFF
--- a/mailstore/dummy_mailstore_test.go
+++ b/mailstore/dummy_mailstore_test.go
@@ -1,6 +1,10 @@
 package mailstore
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jordwest/imap-server/types"
+)
 
 func getDefaultInbox(t *testing.T) DummyMailbox {
 	m := NewDummyMailstore()
@@ -38,37 +42,37 @@ func assertMessageUIDs(t *testing.T, msgs []Message, uids []uint32) {
 
 func TestMessageSetBySequenceNumber(t *testing.T) {
 	inbox := getDefaultInbox(t)
-	msgs := inbox.MessageSetBySequenceNumber(SequenceSet{
-		SequenceRange{min: "1", max: ""},
-		SequenceRange{min: "4", max: "*"},
+	msgs := inbox.MessageSetBySequenceNumber(types.SequenceSet{
+		types.SequenceRange{Min: "1", Max: ""},
+		types.SequenceRange{Min: "4", Max: "*"},
 	})
 	assertMessageUIDs(t, msgs, []uint32{10})
 
-	msgs = inbox.MessageSetBySequenceNumber(SequenceSet{
-		SequenceRange{min: "2", max: "3"},
+	msgs = inbox.MessageSetBySequenceNumber(types.SequenceSet{
+		types.SequenceRange{Min: "2", Max: "3"},
 	})
 	assertMessageUIDs(t, msgs, []uint32{11, 12})
 }
 
 func TestMessageSetByUID(t *testing.T) {
 	inbox := getDefaultInbox(t)
-	msgs := inbox.MessageSetByUID(SequenceSet{
-		SequenceRange{min: "10", max: "*"},
+	msgs := inbox.MessageSetByUID(types.SequenceSet{
+		types.SequenceRange{Min: "10", Max: "*"},
 	})
 	assertMessageUIDs(t, msgs, []uint32{10, 11, 12})
 
-	msgs = inbox.MessageSetByUID(SequenceSet{
-		SequenceRange{min: "3", max: "9"},
+	msgs = inbox.MessageSetByUID(types.SequenceSet{
+		types.SequenceRange{Min: "3", Max: "9"},
 	})
 	assertMessageUIDs(t, msgs, []uint32{})
 
-	msgs = inbox.MessageSetByUID(SequenceSet{
-		SequenceRange{min: "11", max: "12"},
+	msgs = inbox.MessageSetByUID(types.SequenceSet{
+		types.SequenceRange{Min: "11", Max: "12"},
 	})
 	assertMessageUIDs(t, msgs, []uint32{11, 12})
 
-	msgs = inbox.MessageSetByUID(SequenceSet{
-		SequenceRange{min: "*", max: ""},
+	msgs = inbox.MessageSetByUID(types.SequenceSet{
+		types.SequenceRange{Min: "*", Max: ""},
 	})
 	assertMessageUIDs(t, msgs, []uint32{12})
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package imap
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -9,10 +10,15 @@ import (
 
 func TestDataRace(t *testing.T) {
 	s := NewServer(mailstore.NewDummyMailstore())
-	s.Addr = "127.0.0.1:10143"
+	addr := "127.0.0.1:10143"
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
-		s.ListenAndServe()
+		s.Serve(l)
 	}()
 	time.Sleep(time.Millisecond)
-	s.Close()
+	l.Close()
 }

--- a/util/formatting_test.go
+++ b/util/formatting_test.go
@@ -11,7 +11,7 @@ func TestSplitParams(t *testing.T) {
 		"FLAGS",
 	}
 	params := strings.Join(originalList, " ")
-	result := splitParams(params)
+	result := SplitParams(params)
 	for index, param := range originalList {
 		if result[index] != param {
 			t.Fatalf("Param %d does not match expected:\n"+


### PR DESCRIPTION
A couple of broken tests have been fixed. This was due to refactored changes not being reflected everywhere. Serve was changed so that it's closer to that in net/http (as I think was the original intention). It takes a listener. This makes it possible to listen on multiple interfaces and ports using the same server. Close was removed as it's unnecessary now.